### PR TITLE
Add error checking to api-request

### DIFF
--- a/src/spoon/nodes.clj
+++ b/src/spoon/nodes.clj
@@ -1,22 +1,14 @@
 (ns spoon.nodes
   (:require [spoon.core :as client]))
 
-(comment "Fix me: Use new spoon.core/api-request api"
-  (defn list-nodes []
-    (client/request "nodes"))
+(defn get-nodes [org & [options]]
+  (client/api-request
+    (merge options {:method :get, :path (format "/organizations/%s/nodes" org)})))
 
-  (defn get-node
-    [hostname]
-    (client/request :get (format "nodes/%s" hostname)))
+(defn get-node [org node & [options]]
+  (client/api-request
+    (merge options {:method :get, :path (format "/organizations/%s/nodes/%s" org node)})))
 
-  (defn create-node
-    [hostname & params]
-    (client/request :post (format "nodes/%s" hostname) params))
-
-  (defn delete-node
-    [hostname]
-    (client/request :delete (format "nodes/%s" hostname)))
-
-  (defn edit-node
-    [hostname & params]
-    (client/request :put (format "nodes/%s" hostname) params)))
+(defn delete-node [org node & [options]]
+  (client/api-request
+    (merge options {:method :delete, :path (format "/organizations/%s/nodes/%s" org node)})))


### PR DESCRIPTION
Looks to see if the response from the server comes back http 200 before
trying to parse the body as json. If any other response code is returned
with throw an exception.

Also, adds docuementation to the primary entry point
'spoon.core/api-request, and adds a helper for creating the minimal
required options with the 'spoon.core/client-info function.
