### PR TITLE
Update search

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.bloomberg.inf/spoon "0.3.1-SNAPSHOT"
+(defproject com.bloomberg.inf/spoon "0.3.2-SNAPSHOT"
   :description "Chef Server API client written in Clojure."
   :url "https://github.com/johnbellone/spoon"
   :license {:name "Apache 2.0"

--- a/src/spoon/search.clj
+++ b/src/spoon/search.clj
@@ -1,15 +1,22 @@
 (ns spoon.search
+  "Exposes chef search endpoints"
   (:require [spoon.core :as client]))
 
 (defn search-index
+  "Internal: Generic search request, takes the index to use, along with the
+  organization to search, the search query and pagination options. Prefer using
+  the index specific functions in this namespace rather than using this
+  directly."
   [{:keys [index org q pagination options]
     :or {pagination {}, options {}}}]
-  {:pre [(#{"node" "client" "role"} index)]}
+  {:pre [(#{"node" "client" "role" "environment" "policyfiles"} index)]}
   (let [endpoint (str "/organizations/%s/search/" index)
         params (assoc options :query (assoc pagination :q q))]
     (client/api-request :get endpoint [org] params)))
 
 (defn nodes
+  "Search for nodes withing org. Specify a search query and pagination options
+  (rows, keys, sort) as per https://docs.chef.io/knife_search.html#syntax."
   [org q pagination & [options]]
   (search-index
     {:index "node"
@@ -25,6 +32,8 @@
   (client/api-request :get "/organizations/%s/search/client" [org] options))
 
 (defn clients
+  "Search for clients withing org. Specify a search query and pagination options
+  (rows, keys, sort) as per https://docs.chef.io/knife_search.html#syntax."
   [org q pagination & [options]]
   (search-index
     {:index "client"
@@ -39,7 +48,9 @@
   [org & [options]]
   (client/api-request :get "/organizations/%s/search/client" [org] options))
 
-(defn role
+(defn roles
+  "Search for roless withing org. Specify a search query and pagination options
+  (rows, keys, sort) as per https://docs.chef.io/knife_search.html#syntax."
   [org q pagination & [options]]
   (search-index
     {:index "role"
@@ -53,3 +64,15 @@
   get-roles
   [org & [options]]
   (client/api-request :get "/organizations/%s/search/role" [org] options))
+
+
+(defn environments
+  "Search for environments withing org. Specify a search query and pagination options
+  (rows, keys, sort) as per https://docs.chef.io/knife_search.html#syntax."
+  [org q pagination & [options]]
+  (search-index
+    {:index "environment"
+     :org org
+     :q q
+     :pagination pagination
+     :options options}))

--- a/src/spoon/search.clj
+++ b/src/spoon/search.clj
@@ -1,12 +1,20 @@
 (ns spoon.search
   (:require [spoon.core :as client]))
 
-(defn get-nodes [org & [options]]
-  (client/api-request :get "/organizations/%s/search/node" [org] options))
-
-(defn get-clients [org & [options]]
+(defn
+  ^{:deprecated "0.3.3"}
+  get-nodes
+  [org & [options]]
   (client/api-request :get "/organizations/%s/search/client" [org] options))
 
-(defn get-roles [org & [options]]
-  (client/api-request :get "/organizations/%s/search/role" [org] options))
+(defn
+  ^{:deprecated "0.3.3"}
+  get-clients
+  [org & [options]]
+  (client/api-request :get "/organizations/%s/search/client" [org] options))
 
+(defn
+  ^{:deprecated "0.3.3"}
+  get-roles
+  [org & [options]]
+  (client/api-request :get "/organizations/%s/search/role" [org] options))

--- a/src/spoon/search.clj
+++ b/src/spoon/search.clj
@@ -16,7 +16,7 @@
 
 (defn nodes
   "Search for nodes withing org. Specify a search query and pagination options
-  (rows, keys, sort) as per https://docs.chef.io/knife_search.html#syntax."
+  (rows, start, sort) as per https://docs.chef.io/knife_search.html#syntax."
   [org q pagination & [options]]
   (search-index
     {:index "node"
@@ -33,7 +33,7 @@
 
 (defn clients
   "Search for clients withing org. Specify a search query and pagination options
-  (rows, keys, sort) as per https://docs.chef.io/knife_search.html#syntax."
+  (rows, start, sort) as per https://docs.chef.io/knife_search.html#syntax."
   [org q pagination & [options]]
   (search-index
     {:index "client"
@@ -50,7 +50,7 @@
 
 (defn roles
   "Search for roless withing org. Specify a search query and pagination options
-  (rows, keys, sort) as per https://docs.chef.io/knife_search.html#syntax."
+  (rows, start, sort) as per https://docs.chef.io/knife_search.html#syntax."
   [org q pagination & [options]]
   (search-index
     {:index "role"
@@ -68,7 +68,7 @@
 
 (defn environments
   "Search for environments withing org. Specify a search query and pagination options
-  (rows, keys, sort) as per https://docs.chef.io/knife_search.html#syntax."
+  (rows, start, sort) as per https://docs.chef.io/knife_search.html#syntax."
   [org q pagination & [options]]
   (search-index
     {:index "environment"

--- a/src/spoon/search.clj
+++ b/src/spoon/search.clj
@@ -10,5 +10,3 @@
 (defn get-roles [org & [options]]
   (client/api-request :get "/organizations/%s/search/role" [org] options))
 
-(defn get-users [org & [options]]
-  (client/api-request :get "/organizations/%s/search/users" [org] options))

--- a/src/spoon/search.clj
+++ b/src/spoon/search.clj
@@ -1,17 +1,52 @@
 (ns spoon.search
   (:require [spoon.core :as client]))
 
+(defn search-index
+  [{:keys [index org q pagination options]
+    :or {pagination {}, options {}}}]
+  {:pre [(#{"node" "client" "role"} index)]}
+  (let [endpoint (str "/organizations/%s/search/" index)
+        params (assoc options :query (assoc pagination :q q))]
+    (client/api-request :get endpoint [org] params)))
+
+(defn nodes
+  [org q pagination & [options]]
+  (search-index
+    {:index "node"
+     :org org
+     :q q
+     :pagination pagination
+     :options options}))
+
 (defn
   ^{:deprecated "0.3.3"}
   get-nodes
   [org & [options]]
   (client/api-request :get "/organizations/%s/search/client" [org] options))
 
+(defn clients
+  [org q pagination & [options]]
+  (search-index
+    {:index "client"
+     :org org
+     :q q
+     :pagination pagination
+     :options options}))
+
 (defn
   ^{:deprecated "0.3.3"}
   get-clients
   [org & [options]]
   (client/api-request :get "/organizations/%s/search/client" [org] options))
+
+(defn role
+  [org q pagination & [options]]
+  (search-index
+    {:index "role"
+     :org org
+     :q q
+     :pagination pagination
+     :options options}))
 
 (defn
   ^{:deprecated "0.3.3"}


### PR DESCRIPTION
Make the search functions a little more user friendly. Rather than having to build the query manually, they now take `([org q pagination & [options]])`, where q is the search query as per https://docs.chef.io/knife_search.html#syntax, and pagination is a map which lets the caller control `:rows`, `:sort`, and `:start`. The api will return a map with keys `:total`, `:start`, and `:rows`.

An obvious addition to this would be adding `-seq` functions which peeled off the envelope and returned a lazy sequence of all the results. Will probably send another PR for this later.
