### PR TITLE
Lazy search functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+### Added
+- Added easier to use functions for `spoon.search`, which take care of setting
+  the query and pagination parameters.
+### Deprecated
+- The old `get-*` functions in `spoon.search` should be avoided in favor of the
+  new higher level search functions.
+### Removed
+- User search was removed. This doesn't seem to be an index that is available
+  according to the GET indexes call.
+
+[Unreleased]: https://github.com/johnbellone/spoon/compare/v0.3.1...HEAD 

--- a/src/spoon/search.clj
+++ b/src/spoon/search.clj
@@ -17,18 +17,19 @@
 (defn lazy-search
   "Make a version of a search function that returns a lazy sequnce of all
   nodes, rather than taking pagination options."
-  [search nrows]
-  (fn [org q & [options]]
-    (letfn [(step [idx done pending]
-              (lazy-seq
-                (if (seq pending)
-                  (cons (first pending) (step idx false (rest pending)))
-                  (when-not done
-                    (let [more (:rows (search org q {:start idx, :rows nrows} options))]
-                      (step (+ idx nrows)
-                            (< (count more) nrows)
-                            more))))))]
-      (step 1 false []))))
+  ([search] (lazy-search search 64))
+  ([search nrows]
+   (fn [org q & [options]]
+     (letfn [(step [idx done pending]
+               (lazy-seq
+                 (if (seq pending)
+                   (cons (first pending) (step idx false (rest pending)))
+                   (when-not done
+                     (let [more (:rows (search org q {:start idx, :rows nrows} options))]
+                       (step (+ idx nrows)
+                             (< (count more) nrows)
+                             more))))))]
+       (step 1 false [])))))
 
 (defn nodes
   "Search for nodes withing org. Specify a search query and pagination options
@@ -45,7 +46,7 @@
   ^{:arglists '([org q & [opts]])
     :doc "Lazy node search, returns results of query q in org."}
   nodes-seq
-  (lazy-search nodes 64))
+  (lazy-search nodes))
 
 (defn
   ^{:deprecated "0.3.3"}
@@ -68,7 +69,7 @@
   ^{:arglists '([org q & [opts]])
     :doc "Lazy client search, returns results of query q in org."}
   clients-seq
-  (lazy-search clients 64))
+  (lazy-search clients))
 
 (defn
   ^{:deprecated "0.3.3"}
@@ -90,7 +91,7 @@
 (def roles-seq
   ^{:arglists '([org q & [opts]])
     :doc "Lazy roles search, returns results of query q in org."}
-  (lazy-search roles 64))
+  (lazy-search roles))
 
 (defn
   ^{:deprecated "0.3.3"}
@@ -113,4 +114,4 @@
   ^{:arglists '([org q & [opts]])
     :doc "Lazy environment search, returns results of query q in org."}
   environments-seq
-  (lazy-search environments 64))
+  (lazy-search environments))

--- a/src/spoon/search.clj
+++ b/src/spoon/search.clj
@@ -15,8 +15,9 @@
     (client/api-request :get endpoint [org] params)))
 
 (defn lazy-search
-  "Make a version of a search function that returns a lazy sequnce of all
-  nodes, rather than taking pagination options."
+  "Internal: Make a version of a search function that returns a lazy sequnce of
+  all nodes, rather than taking pagination options. Again, prefer using the *-seq
+  functions in this namespace rathern than calling this directly."
   ([search] (lazy-search search 64))
   ([search nrows]
    (fn [org q & [options]]

--- a/src/spoon/search.clj
+++ b/src/spoon/search.clj
@@ -41,7 +41,11 @@
      :pagination pagination
      :options options}))
 
-(def nodes-seq (lazy-search nodes 64))
+(def
+  ^{:arglists '([org q & [opts]])
+    :doc "Lazy node search, returns results of query q in org."}
+  nodes-seq
+  (lazy-search nodes 64))
 
 (defn
   ^{:deprecated "0.3.3"}
@@ -60,7 +64,11 @@
      :pagination pagination
      :options options}))
 
-(def clients-seq (lazy-search clients 64))
+(def
+  ^{:arglists '([org q & [opts]])
+    :doc "Lazy client search, returns results of query q in org."}
+  clients-seq
+  (lazy-search clients 64))
 
 (defn
   ^{:deprecated "0.3.3"}
@@ -79,7 +87,10 @@
      :pagination pagination
      :options options}))
 
-(def roles-seq (lazy-search roles 64))
+(def roles-seq
+  ^{:arglists '([org q & [opts]])
+    :doc "Lazy roles search, returns results of query q in org."}
+  (lazy-search roles 64))
 
 (defn
   ^{:deprecated "0.3.3"}
@@ -98,4 +109,8 @@
      :pagination pagination
      :options options}))
 
-(def environments-seq (lazy-search environments 64))
+(def
+  ^{:arglists '([org q & [opts]])
+    :doc "Lazy environment search, returns results of query q in org."}
+  environments-seq
+  (lazy-search environments 64))

--- a/src/spoon/search.clj
+++ b/src/spoon/search.clj
@@ -32,20 +32,27 @@
                              more))))))]
        (step 1 false [])))))
 
-(defn nodes
-  "Search for nodes withing org. Specify a search query and pagination options
-  (rows, start, sort) as per https://docs.chef.io/knife_search.html#syntax."
-  [org q pagination & [options]]
-  (search-index
-    {:index "node"
-     :org org
-     :q q
-     :pagination pagination
-     :options options}))
+(defmacro make-search
+  "Create a new search of index type. Creates both pagination enabled and lazy-seq versions."
+  [sym index]
+  `(do
+    (defn ~sym
+      ~(format
+         "Search for %s within org. Specify a search query and pagination options
+         (rows, start, sort) as per https://docs.chef.io/knife_search.html#syntax."
+         sym)
+      [org# q# pagination# & [options#]]
+      (search-index
+        {:index ~index
+         :org org#
+         :q q#
+         :pagination pagination#
+         :options options#}))
+    (def ^{:arglists '([org q & [opts]])
+           :doc ~(format "Lazy search for %s, returns results of query q in org." ~index)}
+      ~(symbol (str sym "-seq")) (lazy-search ~sym))))
 
-(def ^{:arglists '([org q & [opts]])
-       :doc "Lazy node search, returns results of query q in org."}
-  nodes-seq (lazy-search nodes))
+(make-search nodes "node")
 
 (defn
   ^{:deprecated "0.3.3"}
@@ -53,20 +60,7 @@
   [org & [options]]
   (client/api-request :get "/organizations/%s/search/client" [org] options))
 
-(defn clients
-  "Search for clients withing org. Specify a search query and pagination options
-  (rows, start, sort) as per https://docs.chef.io/knife_search.html#syntax."
-  [org q pagination & [options]]
-  (search-index
-    {:index "client"
-     :org org
-     :q q
-     :pagination pagination
-     :options options}))
-
-(def ^{:arglists '([org q & [opts]])
-       :doc "Lazy client search, returns results of query q in org."}
-  clients-seq (lazy-search clients))
+(make-search clients "client")
 
 (defn
   ^{:deprecated "0.3.3"}
@@ -74,20 +68,7 @@
   [org & [options]]
   (client/api-request :get "/organizations/%s/search/client" [org] options))
 
-(defn roles
-  "Search for roless withing org. Specify a search query and pagination options
-  (rows, start, sort) as per https://docs.chef.io/knife_search.html#syntax."
-  [org q pagination & [options]]
-  (search-index
-    {:index "role"
-     :org org
-     :q q
-     :pagination pagination
-     :options options}))
-
-(def ^{:arglists '([org q & [opts]])
-       :doc "Lazy roles search, returns results of query q in org."}
-  roles-seq (lazy-search roles))
+(make-search roles "role")
 
 (defn
   ^{:deprecated "0.3.3"}
@@ -95,17 +76,4 @@
   [org & [options]]
   (client/api-request :get "/organizations/%s/search/role" [org] options))
 
-(defn environments
-  "Search for environments withing org. Specify a search query and pagination options
-  (rows, start, sort) as per https://docs.chef.io/knife_search.html#syntax."
-  [org q pagination & [options]]
-  (search-index
-    {:index "environment"
-     :org org
-     :q q
-     :pagination pagination
-     :options options}))
-
-(def ^{:arglists '([org q & [opts]])
-       :doc "Lazy environment search, returns results of query q in org."}
-  environments-seq (lazy-search environments))
+(make-search environments "environment")

--- a/src/spoon/search.clj
+++ b/src/spoon/search.clj
@@ -43,11 +43,9 @@
      :pagination pagination
      :options options}))
 
-(def
-  ^{:arglists '([org q & [opts]])
-    :doc "Lazy node search, returns results of query q in org."}
-  nodes-seq
-  (lazy-search nodes))
+(def ^{:arglists '([org q & [opts]])
+       :doc "Lazy node search, returns results of query q in org."}
+  nodes-seq (lazy-search nodes))
 
 (defn
   ^{:deprecated "0.3.3"}
@@ -66,11 +64,9 @@
      :pagination pagination
      :options options}))
 
-(def
-  ^{:arglists '([org q & [opts]])
-    :doc "Lazy client search, returns results of query q in org."}
-  clients-seq
-  (lazy-search clients))
+(def ^{:arglists '([org q & [opts]])
+       :doc "Lazy client search, returns results of query q in org."}
+  clients-seq (lazy-search clients))
 
 (defn
   ^{:deprecated "0.3.3"}
@@ -89,10 +85,9 @@
      :pagination pagination
      :options options}))
 
-(def roles-seq
-  ^{:arglists '([org q & [opts]])
-    :doc "Lazy roles search, returns results of query q in org."}
-  (lazy-search roles))
+(def ^{:arglists '([org q & [opts]])
+       :doc "Lazy roles search, returns results of query q in org."}
+  roles-seq (lazy-search roles))
 
 (defn
   ^{:deprecated "0.3.3"}
@@ -111,8 +106,6 @@
      :pagination pagination
      :options options}))
 
-(def
-  ^{:arglists '([org q & [opts]])
-    :doc "Lazy environment search, returns results of query q in org."}
-  environments-seq
-  (lazy-search environments))
+(def ^{:arglists '([org q & [opts]])
+       :doc "Lazy environment search, returns results of query q in org."}
+  environments-seq (lazy-search environments))

--- a/src/spoon/search.clj
+++ b/src/spoon/search.clj
@@ -54,24 +54,21 @@
 
 (make-search nodes "node")
 
-(defn
-  ^{:deprecated "0.3.3"}
+(defn ^{:deprecated "0.3.3"}
   get-nodes
   [org & [options]]
   (client/api-request :get "/organizations/%s/search/client" [org] options))
 
 (make-search clients "client")
 
-(defn
-  ^{:deprecated "0.3.3"}
+(defn ^{:deprecated "0.3.3"}
   get-clients
   [org & [options]]
   (client/api-request :get "/organizations/%s/search/client" [org] options))
 
 (make-search roles "role")
 
-(defn
-  ^{:deprecated "0.3.3"}
+(defn ^{:deprecated "0.3.3"}
   get-roles
   [org & [options]]
   (client/api-request :get "/organizations/%s/search/role" [org] options))


### PR DESCRIPTION
Adds `*-seq` functions to each search. These functions return a lazy sequence of all the search results without having to specify pagination parameters. Fetches in batch sizes of 64 records by default.
